### PR TITLE
[SC-240] Pot Rate Source

### DIFF
--- a/src/PotRateSource.sol
+++ b/src/PotRateSource.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.0;
 
-import { IRateSource } from './interfaces/IRateSource.sol';
+import { IRateSource } from "./interfaces/IRateSource.sol";
 
 interface IPot {
     function dsr() external view returns (uint256);

--- a/src/PotRateSource.sol
+++ b/src/PotRateSource.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.0;
+
+import { IRateSource } from './interfaces/IRateSource.sol';
+
+interface IPot {
+    function dsr() external view returns (uint256);
+}
+
+contract PotRateSource is IRateSource {
+
+    IPot public immutable pot;
+
+    constructor(address _pot) {
+        pot = IPot(_pot);
+    }
+
+    function getAPR() external override view returns (uint256) {
+        return (pot.dsr() - 1e27) * 365 days;
+    }
+
+}

--- a/src/RateTargetBaseInterestRateStrategy.sol
+++ b/src/RateTargetBaseInterestRateStrategy.sol
@@ -10,9 +10,7 @@ import {IDefaultInterestRateStrategy} from 'aave-v3-core/contracts/interfaces/ID
 import {IReserveInterestRateStrategy} from 'aave-v3-core/contracts/interfaces/IReserveInterestRateStrategy.sol';
 import {IPoolAddressesProvider} from 'aave-v3-core/contracts/interfaces/IPoolAddressesProvider.sol';
 
-interface IRateSource {
-  function getAPR() external view returns (uint256);
-}
+import {IRateSource} from './interfaces/IRateSource.sol';
 
 /**
  * @title RateTargetBaseInterestRateStrategy contract

--- a/src/RateTargetKinkInterestRateStrategy.sol
+++ b/src/RateTargetKinkInterestRateStrategy.sol
@@ -10,9 +10,7 @@ import {IDefaultInterestRateStrategy} from 'aave-v3-core/contracts/interfaces/ID
 import {IReserveInterestRateStrategy} from 'aave-v3-core/contracts/interfaces/IReserveInterestRateStrategy.sol';
 import {IPoolAddressesProvider} from 'aave-v3-core/contracts/interfaces/IPoolAddressesProvider.sol';
 
-interface IRateSource {
-  function getAPR() external view returns (uint256);
-}
+import {IRateSource} from './interfaces/IRateSource.sol';
 
 /**
  * @title RateTargetKinkInterestRateStrategy contract

--- a/src/interfaces/IRateSource.sol
+++ b/src/interfaces/IRateSource.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity >=0.8.0;
+
+interface IRateSource {
+    function getAPR() external view returns (uint256);
+}

--- a/test/InterestRateStrategyBase.t.sol
+++ b/test/InterestRateStrategyBase.t.sol
@@ -3,11 +3,11 @@ pragma solidity ^0.8.0;
 
 import "forge-std/Test.sol";
 
-import { IDefaultInterestRateStrategy }       from 'aave-v3-core/contracts/interfaces/IDefaultInterestRateStrategy.sol';
-import { DataTypes }                          from 'aave-v3-core/contracts/protocol/libraries/types/DataTypes.sol';
-import { DefaultReserveInterestRateStrategy } from 'aave-v3-core/contracts/protocol/pool/DefaultReserveInterestRateStrategy.sol';
+import { IDefaultInterestRateStrategy }       from "aave-v3-core/contracts/interfaces/IDefaultInterestRateStrategy.sol";
+import { DataTypes }                          from "aave-v3-core/contracts/protocol/libraries/types/DataTypes.sol";
+import { DefaultReserveInterestRateStrategy } from "aave-v3-core/contracts/protocol/pool/DefaultReserveInterestRateStrategy.sol";
 
-import { MockERC20 } from 'erc20-helpers/MockERC20.sol';
+import { MockERC20 } from "erc20-helpers/MockERC20.sol";
 
 abstract contract InterestRateStrategyBaseTest is Test {
 

--- a/test/PotRateSource.t.sol
+++ b/test/PotRateSource.t.sol
@@ -21,6 +21,7 @@ contract PotMock {
 
 contract PotRateSourceTest is Test {
 
+    // To calculate: bc -l <<< 'scale=27; e( l(1.05)/(60 * 60 * 24 * 365) )'
     uint256 constant FIVE_PCT_APY_DSR = 1.000000001547125957863212448e27;
     uint256 constant FIVE_PCT_APY_APR = 0.048790164207174267760128000e27;
 

--- a/test/PotRateSource.t.sol
+++ b/test/PotRateSource.t.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+
+import { PotRateSource } from "../src/PotRateSource.sol";
+
+contract PotMock {
+
+    uint256 public dsr;
+
+    constructor(uint256 _dsr) {
+        dsr = _dsr;
+    }
+
+    function setDSR(uint256 _dsr) external {
+        dsr = _dsr;
+    }
+
+}
+
+contract PotRateSourceTest is Test {
+
+    uint256 constant FIVE_PCT_APY_DSR = 1.000000001547125957863212448e27;
+    uint256 constant FIVE_PCT_APY_APR = 0.048790164207174267760128000e27;
+
+    PotMock pot;
+
+    PotRateSource rateSource;
+
+    function setUp() public {
+        pot = new PotMock(FIVE_PCT_APY_DSR);
+
+        rateSource = new PotRateSource(address(pot));
+    }
+
+    function test_constructor() public {
+        assertEq(address(rateSource.pot()), address(pot));
+    }
+
+    function test_bad_dsr_value() public {
+        pot.setDSR(1e27 - 1);
+
+        vm.expectRevert(stdError.arithmeticError);
+        rateSource.getAPR();
+    }
+
+    function test_getAPR() public {
+        assertEq(rateSource.getAPR(), FIVE_PCT_APY_APR);
+
+        pot.setDSR(1e27);
+
+        assertEq(rateSource.getAPR(), 0);
+    }
+
+}

--- a/test/SparkDaiMarketInterestRateStrategyIntegration.t.sol
+++ b/test/SparkDaiMarketInterestRateStrategyIntegration.t.sol
@@ -14,12 +14,12 @@ import { RateTargetBaseInterestRateStrategy } from "../src/RateTargetBaseInteres
 contract SparkDaiMarketInterestRateStrategyIntegrationTest is Test {
 
     IPoolAddressesProvider poolAddressesProvider = IPoolAddressesProvider(0x02C3eA4e34C0cBd694D2adFa2c690EECbC1793eE);
-    IPool pool                                   = IPool(0xC13e21B648A5Ee794902342038FF3aDAB66BE987);
-    IPoolConfigurator configurator               = IPoolConfigurator(0x542DBa469bdE58FAeE189ffB60C6b49CE60E0738);
+    IPool                  pool                  =                  IPool(0xC13e21B648A5Ee794902342038FF3aDAB66BE987);
+    IPoolConfigurator      configurator          =      IPoolConfigurator(0x542DBa469bdE58FAeE189ffB60C6b49CE60E0738);
 
     address dai   = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
     address pot   = 0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7;
-    address admin = 0x3300f198988e4C9C63F75dF86De36421f06af8c4;     // SubDAO Proxy
+    address admin = 0x3300f198988e4C9C63F75dF86De36421f06af8c4;  // SubDAO Proxy
 
     PotRateSource                      rateSource;
     RateTargetBaseInterestRateStrategy interestStrategy;

--- a/test/SparkDaiMarketInterestRateStrategyIntegration.t.sol
+++ b/test/SparkDaiMarketInterestRateStrategyIntegration.t.sol
@@ -17,9 +17,9 @@ contract SparkDaiMarketInterestRateStrategyIntegrationTest is Test {
     IPool pool                                   = IPool(0xC13e21B648A5Ee794902342038FF3aDAB66BE987);
     IPoolConfigurator configurator               = IPoolConfigurator(0x542DBa469bdE58FAeE189ffB60C6b49CE60E0738);
 
-    address dai          = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
-    address pot          = 0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7;
-    address admin        = 0x3300f198988e4C9C63F75dF86De36421f06af8c4;     // SubDAO Proxy
+    address dai   = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+    address pot   = 0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7;
+    address admin = 0x3300f198988e4C9C63F75dF86De36421f06af8c4;     // SubDAO Proxy
 
     PotRateSource                      rateSource;
     RateTargetBaseInterestRateStrategy interestStrategy;
@@ -30,16 +30,16 @@ contract SparkDaiMarketInterestRateStrategyIntegrationTest is Test {
         rateSource = new PotRateSource(pot);
 
         interestStrategy = new RateTargetBaseInterestRateStrategy({
-            provider: poolAddressesProvider,
-            rateSource: address(rateSource),
-            optimalUsageRatio: 1e27,
-            baseVariableBorrowRateSpread: 0.005e27,
-            variableRateSlope1: 0,
-            variableRateSlope2: 0,
-            stableRateSlope1: 0,
-            stableRateSlope2: 0,
-            baseStableRateOffset: 0,
-            stableRateExcessOffset: 0,
+            provider:                      poolAddressesProvider,
+            rateSource:                    address(rateSource),
+            optimalUsageRatio:             1e27,
+            baseVariableBorrowRateSpread:  0.005e27,
+            variableRateSlope1:            0,
+            variableRateSlope2:            0,
+            stableRateSlope1:              0,
+            stableRateSlope2:              0,
+            baseStableRateOffset:          0,
+            stableRateExcessOffset:        0,
             optimalStableToTotalDebtRatio: 0
         });
     }

--- a/test/SparkDaiMarketInterestRateStrategyIntegration.t.sol
+++ b/test/SparkDaiMarketInterestRateStrategyIntegration.t.sol
@@ -14,8 +14,8 @@ import { RateTargetBaseInterestRateStrategy } from "../src/RateTargetBaseInteres
 contract SparkDaiMarketInterestRateStrategyIntegrationTest is Test {
 
     IPoolAddressesProvider poolAddressesProvider = IPoolAddressesProvider(0x02C3eA4e34C0cBd694D2adFa2c690EECbC1793eE);
-    IPool                  pool                  =                  IPool(0xC13e21B648A5Ee794902342038FF3aDAB66BE987);
-    IPoolConfigurator      configurator          =      IPoolConfigurator(0x542DBa469bdE58FAeE189ffB60C6b49CE60E0738);
+    IPool                  pool                  = IPool(0xC13e21B648A5Ee794902342038FF3aDAB66BE987);
+    IPoolConfigurator      configurator          = IPoolConfigurator(0x542DBa469bdE58FAeE189ffB60C6b49CE60E0738);
 
     address dai   = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
     address pot   = 0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7;

--- a/test/SparkDaiMarketInterestRateStrategyIntegration.t.sol
+++ b/test/SparkDaiMarketInterestRateStrategyIntegration.t.sol
@@ -86,7 +86,7 @@ contract SparkDaiMarketInterestRateStrategyIntegrationTest is Test {
         _triggerUpdate();
 
         // Should be 0.5% higher than before
-        assertEq(_getBorrowRate(), 0.058790164207174267760128000e27);
+        assertEq(_getBorrowRate(), currentBorrowRate + 0.005e27);
     }
 
     function _getBorrowRate() internal view returns (uint256) {

--- a/test/SparkDaiMarketInterestRateStrategyIntegration.t.sol
+++ b/test/SparkDaiMarketInterestRateStrategyIntegration.t.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+
+import { IPoolAddressesProvider } from "aave-v3-core/contracts/interfaces/IPoolAddressesProvider.sol";
+import { IPool }                  from "aave-v3-core/contracts/interfaces/IPool.sol";
+import { IPoolConfigurator }      from "aave-v3-core/contracts/interfaces/IPoolConfigurator.sol";
+import { IERC20 }                 from "erc20-helpers/interfaces/IERC20.sol";
+
+import { PotRateSource }                      from "../src/PotRateSource.sol";
+import { RateTargetBaseInterestRateStrategy } from "../src/RateTargetBaseInterestRateStrategy.sol";
+
+contract SparkDaiMarketInterestRateStrategyIntegrationTest is Test {
+
+    IPoolAddressesProvider poolAddressesProvider = IPoolAddressesProvider(0x02C3eA4e34C0cBd694D2adFa2c690EECbC1793eE);
+    IPool pool                                   = IPool(0xC13e21B648A5Ee794902342038FF3aDAB66BE987);
+    IPoolConfigurator configurator               = IPoolConfigurator(0x542DBa469bdE58FAeE189ffB60C6b49CE60E0738);
+
+    address dai          = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+    address pot          = 0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7;
+    address admin        = 0x3300f198988e4C9C63F75dF86De36421f06af8c4;     // SubDAO Proxy
+
+    PotRateSource                      rateSource;
+    RateTargetBaseInterestRateStrategy interestStrategy;
+
+    function setUp() public {
+        vm.createSelectFork(getChain("mainnet").rpcUrl, 18_627_155);
+
+        rateSource = new PotRateSource(pot);
+
+        interestStrategy = new RateTargetBaseInterestRateStrategy({
+            provider: poolAddressesProvider,
+            rateSource: address(rateSource),
+            optimalUsageRatio: 1e27,
+            baseVariableBorrowRateSpread: 0.005e27,
+            variableRateSlope1: 0,
+            variableRateSlope2: 0,
+            stableRateSlope1: 0,
+            stableRateSlope2: 0,
+            baseStableRateOffset: 0,
+            stableRateExcessOffset: 0,
+            optimalStableToTotalDebtRatio: 0
+        });
+    }
+
+    function test_update_dai_market_irm() public {
+        uint256 currentBorrowRate = 0.053790164207174267760128000e27;
+
+        // Previous borrow rate
+        assertEq(_getBorrowRate(), currentBorrowRate);
+
+        vm.prank(admin);
+        configurator.setReserveInterestRateStrategyAddress(
+            dai,
+            address(interestStrategy)
+        );
+
+        // Trigger an update from the new IRM
+        deal(dai, address(this), 1e18);
+        IERC20(dai).approve(address(pool), type(uint256).max);
+        pool.supply(dai, 1e18, address(this), 0);
+
+        // Should be unchanged
+        assertEq(_getBorrowRate(), currentBorrowRate);
+    }
+
+    function _getBorrowRate() internal view returns (uint256) {
+        return pool.getReserveData(dai).currentVariableBorrowRate;
+    }
+
+}


### PR DESCRIPTION
This PR adds a rate source which is the `pot`. It will convert the pot DSR value into an APR which can be consumed by one of the rate source IRMs (base or kink). Use cases:

 * DAI Market (Example in the integration test)
 * USDC/USDT markets: can be used with the kink IRM to track the DSR for the kink value which is what we are doing manually right now