### PR TITLE
Require that CappedOracle source only supports 8 decimal sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository contains advanced features to improve SparkLend beyond the core 
 
 ### Oracles
 
+Please note all these oracles are designed for consumption by `AaveOracle` which assumes 8 decimal places.
+
 [FixedPriceOracle](https://github.com/marsfoundation/sparklend-advanced/blob/master/src/FixedPriceOracle.sol): A hardcoded oracle price that never changes. Used for: DAI market
 
 [CappedOracle](https://github.com/marsfoundation/sparklend-advanced/blob/master/src/CappedOracle.sol): Returns `min(market price, hardcoded max price)`. Used for: USDC/USDT markets

--- a/src/CappedOracle.sol
+++ b/src/CappedOracle.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 interface IPriceSource {
     function latestAnswer() external view returns (int256);
+    function decimals() external view returns (uint8);
 }
 
 contract CappedOracle {
@@ -11,7 +12,9 @@ contract CappedOracle {
     int256       public immutable maxPrice;
 
     constructor(address _source, int256 _maxPrice) {
-        require(_maxPrice > 0, "CappedOracle/invalid-max-price");
+        // We require 8 decimals as AaveOracle assumes this
+        require(IPriceSource(_source).decimals() == 8, "CappedOracle/invalid-decimals");
+        require(_maxPrice > 0,                         "CappedOracle/invalid-max-price");
         
         source   = IPriceSource(_source);
         maxPrice = _maxPrice;

--- a/src/CappedOracle.sol
+++ b/src/CappedOracle.sol
@@ -12,7 +12,7 @@ contract CappedOracle {
     int256       public immutable maxPrice;
 
     constructor(address _source, int256 _maxPrice) {
-        // We require 8 decimals as AaveOracle assumes this
+        // 8 decimals required as AaveOracle assumes this
         require(IPriceSource(_source).decimals() == 8, "CappedOracle/invalid-decimals");
         require(_maxPrice > 0,                         "CappedOracle/invalid-max-price");
         

--- a/test/CappedOracle.t.sol
+++ b/test/CappedOracle.t.sol
@@ -14,7 +14,7 @@ contract CappedOracleTest is Test {
     CappedOracle oracle;
 
     function setUp() public {
-        priceSource = new PriceSourceMock(0.8e8);
+        priceSource = new PriceSourceMock(0.8e8, 8);
         oracle      = new CappedOracle(address(priceSource), 1e8);
     }
 
@@ -23,6 +23,13 @@ contract CappedOracleTest is Test {
         assertEq(oracle.decimals(),     8);
         
         assertEq(address(oracle.source()), address(priceSource));
+    }
+
+    function test_invalid_decimals() public {
+        priceSource.setLatestAnswer(0.8e18);
+        priceSource.setDecimals(18);
+        vm.expectRevert("CappedOracle/invalid-decimals");
+        new CappedOracle(address(priceSource), 1e18);
     }
 
     function test_maxPrice_invalid() public {

--- a/test/mocks/PriceSourceMock.sol
+++ b/test/mocks/PriceSourceMock.sol
@@ -4,13 +4,19 @@ pragma solidity ^0.8.0;
 contract PriceSourceMock {
 
     int256 public latestAnswer;
+    uint8  public decimals;
 
-    constructor(int256 _latestAnswer) {
+    constructor(int256 _latestAnswer, uint8 _decimals) {
         latestAnswer = _latestAnswer;
+        decimals     = _decimals;
     }
 
     function setLatestAnswer(int256 _latestAnswer) external {
         latestAnswer = _latestAnswer;
+    }
+
+    function setDecimals(uint8 _decimals) external {
+        decimals = _decimals;
     }
 
 }


### PR DESCRIPTION
`AaveOracle` assumes all price feeds have 8 decimals, so we require this from the original source just to be safe.