### PR TITLE
Bump the solc version and set evm

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,9 +2,10 @@
 src = "src"
 out = "out"
 libs = ["lib"]
-solc_version = '0.8.20'
+solc_version = "0.8.25"
 optimizer = true
 optimizer_runs = 200
+evm_version = "paris"
 remappings = [
     "ds-test/=lib/forge-std/lib/ds-test/src/",
     "erc20-helpers/=lib/erc20-helpers/src/",


### PR DESCRIPTION
There are some issues with contract verification on 0.8.20. I bumped the version and explicitly set the evm version.