### PR TITLE
feat: Adding spETH oracle (DEV-1107)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Please note all these oracles are designed for consumption by `AaveOracle` which
 
 [EZETHExchangeRateOracle](https://github.com/marsfoundation/sparklend-advanced/blob/master/src/EZETHExchangeRateOracle.sol): Provides ezETH/USD by multiplying the ezETH exchange rate by ETH/USD. Used for: ezETH market
 
+[SPETHExchangeRateOracle](https://github.com/marsfoundation/sparklend-advanced/blob/master/src/SPETHExchangeRateOracle.sol): Provides spETH/USD by multiplying the spETH (ERC-4626) exchange rate by ETH/USD. Used for: spETH market
+
 [MorphoUpgradableOracle](https://github.com/marsfoundation/sparklend-advanced/blob/master/src/MorphoUpgradableOracle.sol): Allows Spark Governance to change an oracle for Morpho Blue markets. Planned to be used in Morpho Blue.
 
 ### Custom Interest Rate Strategies

--- a/src/SPETHExchangeRateOracle.sol
+++ b/src/SPETHExchangeRateOracle.sol
@@ -21,12 +21,12 @@ contract SPETHExchangeRateOracle {
     /// @notice The price source for ETH / USD.
     address public immutable ethSource;
 
-    constructor(address _speth, address _ethSource) {
+    constructor(address speth_, address ethSource_) {
         // 8 decimals required as AaveOracle assumes this
-        require(IPriceSource(_ethSource).decimals() == 8, "SPETHExchangeRateOracle/invalid-decimals");
+        require(IPriceSource(ethSource_).decimals() == 8, "SPETHExchangeRateOracle/invalid-decimals");
 
-        speth     = _speth;
-        ethSource = _ethSource;
+        speth     = speth_;
+        ethSource = ethSource_;
     }
 
     function latestAnswer() external view returns (int256) {

--- a/src/SPETHExchangeRateOracle.sol
+++ b/src/SPETHExchangeRateOracle.sol
@@ -33,7 +33,7 @@ contract SPETHExchangeRateOracle {
         int256 ethUsd       = IPriceSource(ethSource).latestAnswer();
         int256 exchangeRate = int256(IERC4626Like(speth).convertToAssets(1e18));
 
-        return (ethUsd <= 0 || exchangeRate <= 0) ? 0 : (exchangeRate * ethUsd) / 1e18;
+        return (ethUsd <= 0 || exchangeRate <= 0) ? int256(0) : (exchangeRate * ethUsd) / 1e18;
     }
 
     function decimals() external pure returns (uint8) {

--- a/src/SPETHExchangeRateOracle.sol
+++ b/src/SPETHExchangeRateOracle.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.0;
+
+import { IPriceSource } from "./interfaces/IPriceSource.sol";
+
+interface IERC4626 {
+    function convertToAssets(uint256 shares) external view returns (uint256);
+}
+
+/**
+ * @title  SPETHExchangeRateOracle
+ * @notice Provides spETH / USD price using ERC-4626 exchange rate × ETH/USD.
+ * @dev    This is a "non-market" price. Any depeg event will be ignored.
+ *         spETH (Spark Savings ETH) is an ERC-4626 vault holding WETH.
+ */
+contract SPETHExchangeRateOracle {
+
+    /// @notice spETH vault contract (ERC-4626).
+    IERC4626 public immutable speth;
+
+    /// @notice The price source for ETH / USD.
+    IPriceSource public immutable ethSource;
+
+    constructor(address _speth, address _ethSource) {
+        // 8 decimals required as AaveOracle assumes this
+        require(IPriceSource(_ethSource).decimals() == 8, "SPETHExchangeRateOracle/invalid-decimals");
+
+        speth     = IERC4626(_speth);
+        ethSource = IPriceSource(_ethSource);
+    }
+
+    function latestAnswer() external view returns (int256) {
+        int256 ethUsd       = ethSource.latestAnswer();
+        int256 exchangeRate = int256(speth.convertToAssets(1e18));
+
+        if (ethUsd <= 0 || exchangeRate <= 0) {
+            return 0;
+        }
+
+        return exchangeRate * ethUsd / 1e18;
+    }
+
+    function decimals() external pure returns (uint8) {
+        return 8;
+    }
+
+}

--- a/test/SPETHExchangeRateOracle.t.sol
+++ b/test/SPETHExchangeRateOracle.t.sol
@@ -43,7 +43,7 @@ contract SPETHExchangeRateOracleTest is Test {
         assertEq(oracle.decimals(),           8);
     }
 
-    function test_invalid_decimals() public {
+    function test_constructor_invalidDecimals() public {
         ethSource.setLatestAnswer(2000e18);
         ethSource.setDecimals(18);
         vm.expectRevert("SPETHExchangeRateOracle/invalid-decimals");

--- a/test/SPETHExchangeRateOracle.t.sol
+++ b/test/SPETHExchangeRateOracle.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.0;
 
-import { Test } from "@forge-std/Test.sol";
+import { Test } from "forge-std/Test.sol";
 
 import { PriceSourceMock } from "./mocks/PriceSourceMock.sol";
 

--- a/test/SPETHExchangeRateOracle.t.sol
+++ b/test/SPETHExchangeRateOracle.t.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+
+import { PriceSourceMock } from "./mocks/PriceSourceMock.sol";
+
+import { SPETHExchangeRateOracle } from "../src/SPETHExchangeRateOracle.sol";
+
+contract SPETHMock {
+
+    uint256 exchangeRate;
+
+    constructor(uint256 _exchangeRate) {
+        exchangeRate = _exchangeRate;
+    }
+
+    function convertToAssets(uint256 shares) external view returns (uint256) {
+        return exchangeRate * shares / 1e18;
+    }
+
+    function setExchangeRate(uint256 _exchangeRate) external {
+        exchangeRate = _exchangeRate;
+    }
+
+}
+
+contract SPETHExchangeRateOracleTest is Test {
+
+    SPETHMock       speth;
+    PriceSourceMock ethSource;
+
+    SPETHExchangeRateOracle oracle;
+
+    function setUp() public {
+        speth     = new SPETHMock(1.0036e18);
+        ethSource = new PriceSourceMock(2000e8, 8);
+        oracle    = new SPETHExchangeRateOracle(address(speth), address(ethSource));
+    }
+
+    function test_constructor() public {
+        assertEq(address(oracle.speth()),     address(speth));
+        assertEq(address(oracle.ethSource()), address(ethSource));
+        assertEq(oracle.decimals(),           8);
+    }
+
+    function test_invalid_decimals() public {
+        ethSource.setLatestAnswer(2000e18);
+        ethSource.setDecimals(18);
+        vm.expectRevert("SPETHExchangeRateOracle/invalid-decimals");
+        new SPETHExchangeRateOracle(address(speth), address(ethSource));
+    }
+
+    function test_latestAnswer_zeroEthUsd() public {
+        ethSource.setLatestAnswer(0);
+        assertEq(oracle.latestAnswer(), 0);
+    }
+
+    function test_latestAnswer_negativeEthUsd() public {
+        ethSource.setLatestAnswer(-1);
+        assertEq(oracle.latestAnswer(), 0);
+    }
+
+    function test_latestAnswer_zeroExchangeRate() public {
+        speth.setExchangeRate(0);
+        assertEq(oracle.latestAnswer(), 0);
+    }
+
+    function test_latestAnswer() public {
+        // 1.0036 * 2000 = 2007.2
+        assertEq(oracle.latestAnswer(), 2007.2e8);
+
+        // 1 * 2000 = 2000
+        speth.setExchangeRate(1e18);
+        assertEq(oracle.latestAnswer(), 2000e8);
+
+        // 1 * 3000 = 3000
+        ethSource.setLatestAnswer(3000e8);
+        assertEq(oracle.latestAnswer(), 3000e8);
+
+        // 1.1 * 2500 = 2750
+        speth.setExchangeRate(1.1e18);
+        ethSource.setLatestAnswer(2500e8);
+        assertEq(oracle.latestAnswer(), 2750e8);
+    }
+
+    function testFuzz_latestAnswer(uint256 exchangeRate, uint256 ethPrice) public {
+        // Bound exchange rate between 1.0 and 2.0 (reasonable LST range)
+        exchangeRate = bound(exchangeRate, 1e18, 2e18);
+        // Bound ETH price between $100 and $100,000
+        ethPrice = bound(ethPrice, 100e8, 100_000e8);
+
+        speth.setExchangeRate(exchangeRate);
+        ethSource.setLatestAnswer(int256(ethPrice));
+
+        int256 result = oracle.latestAnswer();
+        int256 expected = int256(exchangeRate) * int256(ethPrice) / 1e18;
+
+        assertEq(result, expected);
+    }
+
+}

--- a/test/SPETHExchangeRateOracle.t.sol
+++ b/test/SPETHExchangeRateOracle.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.0;
 
-import "forge-std/Test.sol";
+import { Test } from "@forge-std/Test.sol";
 
 import { PriceSourceMock } from "./mocks/PriceSourceMock.sol";
 
@@ -9,28 +9,27 @@ import { SPETHExchangeRateOracle } from "../src/SPETHExchangeRateOracle.sol";
 
 contract SPETHMock {
 
-    uint256 exchangeRate;
+    uint256 public exchangeRate;
 
-    constructor(uint256 _exchangeRate) {
-        exchangeRate = _exchangeRate;
+    constructor(uint256 exchangeRate_) {
+        exchangeRate = exchangeRate_;
     }
 
     function convertToAssets(uint256 shares) external view returns (uint256) {
-        return exchangeRate * shares / 1e18;
+        return (exchangeRate * shares) / 1e18;
     }
 
-    function setExchangeRate(uint256 _exchangeRate) external {
-        exchangeRate = _exchangeRate;
+    function setExchangeRate(uint256 exchangeRate_) external {
+        exchangeRate = exchangeRate_;
     }
 
 }
 
 contract SPETHExchangeRateOracleTest is Test {
 
-    SPETHMock       speth;
-    PriceSourceMock ethSource;
-
+    PriceSourceMock         ethSource;
     SPETHExchangeRateOracle oracle;
+    SPETHMock               speth;
 
     function setUp() public {
         speth     = new SPETHMock(1.0036e18);
@@ -87,6 +86,7 @@ contract SPETHExchangeRateOracleTest is Test {
     function testFuzz_latestAnswer(uint256 exchangeRate, uint256 ethPrice) public {
         // Bound exchange rate between 1.0 and 2.0 (reasonable LST range)
         exchangeRate = bound(exchangeRate, 1e18, 2e18);
+
         // Bound ETH price between $100 and $100,000
         ethPrice = bound(ethPrice, 100e8, 100_000e8);
 
@@ -94,7 +94,7 @@ contract SPETHExchangeRateOracleTest is Test {
         ethSource.setLatestAnswer(int256(ethPrice));
 
         int256 result   = oracle.latestAnswer();
-        int256 expected = int256(exchangeRate) * int256(ethPrice) / 1e18;
+        int256 expected = (int256(exchangeRate) * int256(ethPrice)) / 1e18;
 
         assertEq(result, expected);
     }

--- a/test/SPETHExchangeRateOracle.t.sol
+++ b/test/SPETHExchangeRateOracle.t.sol
@@ -93,7 +93,7 @@ contract SPETHExchangeRateOracleTest is Test {
         speth.setExchangeRate(exchangeRate);
         ethSource.setLatestAnswer(int256(ethPrice));
 
-        int256 result = oracle.latestAnswer();
+        int256 result   = oracle.latestAnswer();
         int256 expected = int256(exchangeRate) * int256(ethPrice) / 1e18;
 
         assertEq(result, expected);

--- a/test/SparkLendMainnetIntegration.t.sol
+++ b/test/SparkLendMainnetIntegration.t.sol
@@ -74,7 +74,7 @@ contract SparkLendMainnetIntegrationTest is Test {
         vm.createSelectFork(getChain("mainnet").rpcUrl, 19895484);  // May 18, 2024
     }
 
-    function test_dai_market_oracle() public {
+    function test_dai_sparklendOracle() public {
         // Set fork state to before this was introduced
         vm.createSelectFork(getChain("mainnet").rpcUrl, 18784436);  // Dec 14, 2023
 
@@ -97,7 +97,7 @@ contract SparkLendMainnetIntegrationTest is Test {
         assertEq(aaveOracle.getAssetPrice(DAI), 1e8);
     }
 
-    function test_dai_market_irm() public {
+    function test_dai_sparklendIRM() public {
         vm.createSelectFork(getChain("mainnet").rpcUrl, 20965077);  // Oct 14, 2024
 
         RateTargetBaseInterestRateStrategy strategy
@@ -149,7 +149,7 @@ contract SparkLendMainnetIntegrationTest is Test {
         assertApproxEqRel(_getBorrowRate(DAI), currentBorrowRate + 0.01e27, 0.001e18);
     }
 
-    function test_eth_market_irm() public {
+    function test_eth_sparklendIRM() public {
         CappedFallbackRateSource rateSource = new CappedFallbackRateSource({
             _source:      LST_RATE_SOURCE,
             _lowerBound:  0.01e18,
@@ -202,7 +202,7 @@ contract SparkLendMainnetIntegrationTest is Test {
         assertEq(_getBorrowRate(ETH), 0.016985713431350567055736333e27);
     }
 
-    function test_usdc_usdt_market_oracles() public {
+    function test_usdc_usdt_sparklendOracles() public {
         // Set fork state to before this was introduced
         vm.createSelectFork(getChain("mainnet").rpcUrl, 18784436);  // Dec 14, 2023
 
@@ -230,7 +230,7 @@ contract SparkLendMainnetIntegrationTest is Test {
         assertEq(aaveOracle.getAssetPrice(USDT), 0.99961441e8);
     }
 
-    function test_usdc_usdt_market_irms() public {
+    function test_usdc_usdt_sparklendIRMs() public {
         vm.createSelectFork(getChain("mainnet").rpcUrl, 20965077);  // Oct 14, 2024
 
         RateTargetKinkInterestRateStrategy strategy
@@ -275,7 +275,7 @@ contract SparkLendMainnetIntegrationTest is Test {
         assertEq(_getBorrowRate(USDT), newRateUSDT, "after1: USDT mismatch");
     }
 
-    function test_reth_market_oracle() public {
+    function test_reth_sparklendOracle() public {
         // Set fork state to before this was introduced
         vm.createSelectFork(getChain("mainnet").rpcUrl, 19015252);  // Jan 15, 2024
 
@@ -301,7 +301,7 @@ contract SparkLendMainnetIntegrationTest is Test {
         assertEq(aaveOracle.getSourceOfAsset(RETH), address(oracle));
     }
 
-    function test_wsteth_market_oracle() public {
+    function test_wsteth_sparklendOracle() public {
         // Set fork state to before this was introduced
         vm.createSelectFork(getChain("mainnet").rpcUrl, 19015252);  // Jan 15, 2024
 
@@ -327,11 +327,12 @@ contract SparkLendMainnetIntegrationTest is Test {
         assertEq(aaveOracle.getSourceOfAsset(WSTETH), address(oracle));
     }
 
-    function test_weeth_market_oracle() public {
+    function test_weeth_sparklendOracle() public {
         WEETHExchangeRateOracle oracle = new WEETHExchangeRateOracle(WEETH, ETHUSD_ORACLE);
 
         vm.expectRevert();  // Not setup yet
-        assertEq(aaveOracle.getAssetPrice(WEETH),    0);
+        aaveOracle.getAssetPrice(WEETH);
+
         assertEq(aaveOracle.getSourceOfAsset(WEETH), address(0));
 
         address[] memory assets = new address[](1);
@@ -352,11 +353,12 @@ contract SparkLendMainnetIntegrationTest is Test {
         assertEq(aaveOracle.getSourceOfAsset(WEETH), address(oracle));
     }
 
-    function test_rseth_market_oracle() public {
+    function test_rseth_sparklendOracle() public {
         RSETHExchangeRateOracle oracle = new RSETHExchangeRateOracle(RSETH_ORACLE, ETHUSD_ORACLE);
 
         vm.expectRevert();  // Not setup yet
-        assertEq(aaveOracle.getAssetPrice(RSETH),    0);
+        aaveOracle.getAssetPrice(RSETH);
+
         assertEq(aaveOracle.getSourceOfAsset(RSETH), address(0));
 
         address[] memory assets = new address[](1);
@@ -377,11 +379,12 @@ contract SparkLendMainnetIntegrationTest is Test {
         assertEq(aaveOracle.getSourceOfAsset(RSETH), address(oracle));
     }
 
-    function test_ezeth_market_oracle() public {
+    function test_ezeth_sparklendOracle() public {
         EZETHExchangeRateOracle oracle = new EZETHExchangeRateOracle(EZETH_ORACLE, ETHUSD_ORACLE);
 
         vm.expectRevert();  // Not setup yet
-        assertEq(aaveOracle.getAssetPrice(EZETH),    0);
+        aaveOracle.getAssetPrice(EZETH);
+
         assertEq(aaveOracle.getSourceOfAsset(EZETH), address(0));
 
         address[] memory assets = new address[](1);
@@ -402,13 +405,14 @@ contract SparkLendMainnetIntegrationTest is Test {
         assertEq(aaveOracle.getSourceOfAsset(EZETH), address(oracle));
     }
 
-    function test_speth_market_oracle() public {
+    function test_speth_sparklendOracle() public {
         vm.createSelectFork(getChain("mainnet").rpcUrl, 24318543);  // Jan 26, 2026
 
         SPETHExchangeRateOracle oracle = new SPETHExchangeRateOracle(SPETH, ETHUSD_ORACLE);
 
         vm.expectRevert(); // SPETH not yet added on SparkLend
-        assertEq(aaveOracle.getAssetPrice(SPETH),    0);
+        aaveOracle.getAssetPrice(SPETH);
+
         assertEq(aaveOracle.getSourceOfAsset(SPETH), address(0));
 
         address[] memory assets = new address[](1);

--- a/test/SparkLendMainnetIntegration.t.sol
+++ b/test/SparkLendMainnetIntegration.t.sol
@@ -99,7 +99,7 @@ contract SparkLendMainnetIntegrationTest is Test {
 
     function test_dai_market_irm() public {
         vm.createSelectFork(getChain("mainnet").rpcUrl, 20965077);  // Oct 14, 2024
-        
+
         RateTargetBaseInterestRateStrategy strategy
             = new RateTargetBaseInterestRateStrategy({
                 provider:                      poolAddressesProvider,
@@ -232,7 +232,7 @@ contract SparkLendMainnetIntegrationTest is Test {
 
     function test_usdc_usdt_market_irms() public {
         vm.createSelectFork(getChain("mainnet").rpcUrl, 20965077);  // Oct 14, 2024
-        
+
         RateTargetKinkInterestRateStrategy strategy
             = new RateTargetKinkInterestRateStrategy({
                 provider:                 poolAddressesProvider,
@@ -278,7 +278,7 @@ contract SparkLendMainnetIntegrationTest is Test {
     function test_reth_market_oracle() public {
         // Set fork state to before this was introduced
         vm.createSelectFork(getChain("mainnet").rpcUrl, 19015252);  // Jan 15, 2024
-        
+
         RETHExchangeRateOracle oracle = new RETHExchangeRateOracle(RETH, ETHUSD_ORACLE);
 
         // Nothing is special about this number, it just happens to be the price at this block
@@ -304,7 +304,7 @@ contract SparkLendMainnetIntegrationTest is Test {
     function test_wsteth_market_oracle() public {
         // Set fork state to before this was introduced
         vm.createSelectFork(getChain("mainnet").rpcUrl, 19015252);  // Jan 15, 2024
-        
+
         WSTETHExchangeRateOracle oracle = new WSTETHExchangeRateOracle(STETH, ETHUSD_ORACLE);
 
         // Nothing is special about this number, it just happens to be the price at this block

--- a/test/SparkLendMainnetIntegration.t.sol
+++ b/test/SparkLendMainnetIntegration.t.sol
@@ -408,8 +408,8 @@ contract SparkLendMainnetIntegrationTest is Test {
         SPETHExchangeRateOracle oracle = new SPETHExchangeRateOracle(SPETH, ETHUSD_ORACLE);
 
         vm.expectRevert(); // SPETH not yet added on SparkLend
-        assertEq(aaveOracle.getAssetPrice(SPETH),       0);
-        assertEq(aaveOracle.getSourceOfAsset(SPETH),    address(0));
+        assertEq(aaveOracle.getAssetPrice(SPETH),    0);
+        assertEq(aaveOracle.getSourceOfAsset(SPETH), address(0));
 
         address[] memory assets = new address[](1);
         assets[0] = SPETH;


### PR DESCRIPTION
Add `SPETHExchangeRateOracle` for pricing [`spETH`](https://github.com/sparkdotfi/spark-address-registry/blob/ef077ff03faf36db3a4c76ca2710264cab211659/src/Ethereum.sol#L37C56-L37C98) (Spark Savings ETH) as collateral on SparkLend.